### PR TITLE
에러 전략 추가

### DIFF
--- a/src/main/java/com/skka/adaptor/common/exception/BadRequestException.java
+++ b/src/main/java/com/skka/adaptor/common/exception/BadRequestException.java
@@ -1,0 +1,14 @@
+package com.skka.adaptor.common.exception;
+
+import lombok.Getter;
+
+@Getter
+public class BadRequestException extends RuntimeException {
+
+    private final int code;
+
+    public BadRequestException(final ErrorType errorType) {
+        super(errorType.getMessage());
+        this.code = errorType.getCode();
+    }
+}

--- a/src/main/java/com/skka/adaptor/common/exception/ErrorType.java
+++ b/src/main/java/com/skka/adaptor/common/exception/ErrorType.java
@@ -1,0 +1,21 @@
+package com.skka.adaptor.common.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorType {
+
+    INVALID_CUSTOMER_NAME(2001, "올바르지 않은 이름입니다."),
+    INVALID_CUSTOMER_EMAIL(2002, "올바르지 않은 이메일입니다."),
+    INVALID_CUSTOMER_TEL(2003, "올바르지 않은 전화번호입니다."),
+
+    INVALID_STUDY_SEAT_STARTED_TIME(3001, "시작 시간은 현재보다 이전일 수 없습니다."),
+    INVALID_STUDY_SEAT_END_TIME(3002, "끝나는 시간은 시작 시간 보다 이전일 수 없습니다."),
+    INVALID_STUDY_SEAT_SEAT_NUMBER(3003, "올바르지 않은 좌석 번호 입니다."),
+    INVALID_STUDY_SEAT_OCCUPIED(3004, "좌석 차지 여부는 NULL일 수 없습니다.");
+
+    private final int code;
+    private final String message;
+}


### PR DESCRIPTION
### 이슈
[19] 에러 전략 추가

### 작업사항
* 프로젝트의 전체적인 에러 전략 추가

### 작업 이유
* 도메인별로 에러를 분류할 수 있어서 한 눈에 보기에 좋기 때문
* 에러가 ErrorType에 모아져 있기 때문에 모든 에러를 한 눈에 볼 수 있고, 문서화하기 편하다.
* 도메인별로 해당 도메인 맞춤 에러를 던지기 때문에 캡슐화가 되어서 좀 더 객체지향적으로 된다.
