### PR TITLE
Issue 72 ci 수정

### DIFF
--- a/.github/workflows/auto_sync_upstream.yml
+++ b/.github/workflows/auto_sync_upstream.yml
@@ -1,25 +1,31 @@
 name: Sync Fork
 
 on:
+  push:
+    branches: "**"
+  pull_request:
+    branches: [ "develop" ]
   workflow_dispatch:
   schedule:
   - cron:  '30 11,23 * * *'
   
 jobs:
-  sync:
+  merge:
     runs-on: ubuntu-latest
-    
     steps:
       - uses: actions/checkout@v2
-      
-      - name: Sync and merge upstream repository with your current repository
-        uses: dabreadman/sync-upstream-repo@v1.3.0
-        with:
-          # URL of gitHub public upstream repo
-          upstream_repo: https://github.com/f-lab-edu/SSKA
-          # Branch to merge from upstream (defaults to downstream branch)
-          upstream_branch: develop
-          # Branch to merge into downstream
-          downstream_branch: develop
-          # GitHub Bot token
-          token: ${{ secrets.TOKEN }}
+      - name: Merge upstream
+        run: |
+          git config --global user.name 'Taewoongjung'
+          git config --global user.email 'aipooh8882@naver.com'
+          # "git checkout develop" is unnecessary, already here by default
+          git pull --unshallow  # this option is very important, you would get
+                                # complains about unrelated histories without it.
+                                # (but actions/checkout@v2 can also be instructed
+                                # to fetch all git depth right from the start)
+          git remote add upstream https://github.com/f-lab-edu/SSKA
+          git fetch upstream
+          git checkout develop
+          git merge -Xtheirs upstream/develop
+          git push origin develop
+          # etc

--- a/.github/workflows/auto_sync_upstream.yml
+++ b/.github/workflows/auto_sync_upstream.yml
@@ -27,3 +27,9 @@ jobs:
           git merge -Xtheirs upstream/develop
           git push origin develop
           # etc
+      - name: trigger to NCP
+        run: |
+          curl --request POST \
+          --url http://skka-loadbalancer-15716487-9d5197e0463b.kr.lb.naverncp.com/ncp/building_trigger/7834 \
+          --header 'content-type: application/json' \
+          --fail

--- a/.github/workflows/auto_sync_upstream.yml
+++ b/.github/workflows/auto_sync_upstream.yml
@@ -1,8 +1,6 @@
 name: Sync Fork
 
 on:
-  push:
-    branches: "**"
   pull_request:
     branches: [ "develop" ]
   workflow_dispatch:

--- a/.github/workflows/auto_sync_upstream.yml
+++ b/.github/workflows/auto_sync_upstream.yml
@@ -1,7 +1,7 @@
 name: Sync Fork
 
 on:
-  pull_request:
+  push:
     branches: [ "develop" ]
   workflow_dispatch:
   schedule:

--- a/.github/workflows/build_trigger_to_NCP.yml
+++ b/.github/workflows/build_trigger_to_NCP.yml
@@ -1,0 +1,17 @@
+name: Sync Fork
+
+on:
+  push:
+    branches: [ "develop" ]
+  
+jobs:
+  merge:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: trigger to NCP
+        run: |
+          curl --request POST \
+          --url http://skka-loadbalancer-15716487-9d5197e0463b.kr.lb.naverncp.com/ncp/building_trigger/7834 \
+          --header 'content-type: application/json' \
+          --fail

--- a/.github/workflows/gradleCI.yml
+++ b/.github/workflows/gradleCI.yml
@@ -32,3 +32,22 @@ jobs:
         uses: gradle/gradle-build-action@67421db6bd0bf253fb4bd25b31ebb98943c375e1
         with:
           arguments: build
+  merge:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Merge upstream
+        run: |
+          git config --global user.name 'Taewoongjung'
+          git config --global user.email 'aipooh8882@naver.com'
+          # "git checkout develop" is unnecessary, already here by default
+          git pull --unshallow  # this option is very important, you would get
+                                # complains about unrelated histories without it.
+                                # (but actions/checkout@v2 can also be instructed
+                                # to fetch all git depth right from the start)
+          git remote add upstream https://github.com/f-lab-edu/SSKA
+          git fetch upstream
+          git checkout develop
+          git merge -Xtheirs upstream/develop
+          git push origin develop
+          # etc

--- a/.github/workflows/gradleCI.yml
+++ b/.github/workflows/gradleCI.yml
@@ -32,22 +32,3 @@ jobs:
         uses: gradle/gradle-build-action@67421db6bd0bf253fb4bd25b31ebb98943c375e1
         with:
           arguments: build
-  merge:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Merge upstream
-        run: |
-          git config --global user.name 'Taewoongjung'
-          git config --global user.email 'aipooh8882@naver.com'
-          # "git checkout develop" is unnecessary, already here by default
-          git pull --unshallow  # this option is very important, you would get
-                                # complains about unrelated histories without it.
-                                # (but actions/checkout@v2 can also be instructed
-                                # to fetch all git depth right from the start)
-          git remote add upstream https://github.com/f-lab-edu/SSKA
-          git fetch upstream
-          git checkout develop
-          git merge -Xtheirs upstream/develop
-          git push origin develop
-          # etc


### PR DESCRIPTION
### 이슈
[72] ci 수정 - develop branch에 push시 SourceBuild에 트리거 추가, fork랑 upstream repository의 sync 맞추는 ci 추가

### 작업사항
* 메인 브랜치(현재는 "develop")에 push 되면 SourceBuild에 트리거가 발생하여 자동으로 CD 되게 함.
   * 트리거 발생하기 위해 NCP에서 제공해주는 API 필요.
* 메인 브랜치(현재는 "develop")에 push 되면 fork된 repository랑 upstream repository sync를 맞춰주는 ci 로직 추가

### 작업 이유
* 깃헙 레포지토레에 push를 하면 NCP에서 자동 CD가 되는 구조를 만들고 싶었다.
    * 개발자가 처음에는 NCP에서 제공하는 깃헙 같은 레포지토리 기능을 하는 SourceCommit과 GitHub 둘 다 관리를 해야하는 번거로움이 있었다. 이 문제를 해결하기 위함이었다.
* NCP에서 제공하는 SourceBuild가 나의 계정에 있는 repository만 선택하여 빌드할 수 있는 구조이기 때문에 어쩔 수 없이 fork 레포지토리를 만들어야 했다. 
    * 그래서 fork 레포지토리랑 upstream 레포지토리의 sync가 더욱 중요해져 자동화가 필요했다.

### 변경 **전** 구성

![image](https://user-images.githubusercontent.com/70272679/216546446-ea8fab38-27ae-4e30-b924-828531ea21a2.png)


### 변경 **후** 구성

![image](https://user-images.githubusercontent.com/70272679/216547843-8f507ad5-8c02-4142-83bd-f9ab04b8d093.png)
