### PR TITLE
Issue 74 NCP 에서 제공하는 api로 souce build에 트리거 날리는 api 추가

### DIFF
--- a/src/main/java/com/skka/adaptor/config/PropertyConfig.java
+++ b/src/main/java/com/skka/adaptor/config/PropertyConfig.java
@@ -1,0 +1,13 @@
+package com.skka.adaptor.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.PropertySource;
+import org.springframework.context.annotation.PropertySources;
+
+@Configuration
+@PropertySources({
+    @PropertySource("classpath:properties/env.properties")
+})
+public class PropertyConfig {
+
+}

--- a/src/main/java/com/skka/adaptor/controller/navercloudplatform/NcpController.java
+++ b/src/main/java/com/skka/adaptor/controller/navercloudplatform/NcpController.java
@@ -1,0 +1,37 @@
+package com.skka.adaptor.controller.navercloudplatform;
+
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class NcpController extends NcpService {
+
+    private String list_url = "/api/v1/project";
+
+    @GetMapping(value = "/ncp/list")
+    public ResponseEntity<Object> lookForList() throws Exception {
+
+        String timeStamp = String.valueOf(System.currentTimeMillis());
+
+        return ResponseEntity.status(HttpStatus.OK).body(ncpLookForList(
+            timeStamp, HttpMethod.GET, list_url
+        ));
+    }
+
+    @PostMapping(value = "/ncp/building_trigger/{projectId}")
+    public ResponseEntity<Object> triggerBuild(
+        @PathVariable final String projectId
+    ) throws Exception {
+
+        String timeStamp = String.valueOf(System.currentTimeMillis());
+        String build_trigger_url = "/api/v1/project/" + projectId + "/build";
+        return ResponseEntity.status(HttpStatus.OK).body(ncpHookBuildingTrigger(
+            timeStamp, HttpMethod.POST, build_trigger_url
+        ));
+    }
+}

--- a/src/main/java/com/skka/adaptor/controller/navercloudplatform/NcpService.java
+++ b/src/main/java/com/skka/adaptor/controller/navercloudplatform/NcpService.java
@@ -1,0 +1,87 @@
+package com.skka.adaptor.controller.navercloudplatform;
+
+import java.net.URI;
+import java.nio.charset.Charset;
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import org.apache.tomcat.util.codec.binary.Base64;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+public class NcpService {
+
+    private String accessKey = "";
+    private String secretKey = "";
+
+    private RestTemplate restTemplate = new RestTemplate();
+
+    public Object ncpLookForList(String timeStamp, HttpMethod method, String url) throws Exception {
+
+        HttpHeaders httpHeaders = getNcloudUserApiHeader(method, url, timeStamp);
+
+        URI uri = UriComponentsBuilder
+            .fromUriString("https://sourcebuild.apigw.ntruss.com")
+            .path("/api/v1/project")
+            .encode().build()
+            .toUri();
+
+        HttpEntity request = new HttpEntity(httpHeaders);
+        ResponseEntity<?> response = restTemplate.exchange(uri, HttpMethod.GET, request, String.class);
+
+        return response.getBody();
+    }
+
+    private String makeSignature(String timeStamp, String method, String url) throws Exception {
+        String message = new StringBuilder()
+            .append(method)
+            .append(" ")
+            .append(url)
+            .append("\n")
+            .append(timeStamp)
+            .append("\n")
+            .append(accessKey)
+            .toString();
+        SecretKeySpec signingKey = new SecretKeySpec(secretKey.getBytes("UTF-8"), "HmacSHA256");
+        Mac mac = Mac.getInstance("HmacSHA256");
+        mac.init(signingKey);
+        byte[] rawHmac = mac.doFinal(message.getBytes("UTF-8"));
+        String encodeBase64String = Base64.encodeBase64String(rawHmac);
+        return encodeBase64String;
+    }
+
+    private HttpHeaders getNcloudUserApiHeader(HttpMethod method, String url, String timeStamp) {
+        try {
+            MediaType mediaType = new MediaType("application", "json", Charset.forName("UTF-8"));
+
+            HttpHeaders httpHeaders = new HttpHeaders();
+            httpHeaders.add("x-ncp-apigw-timestamp", timeStamp);
+            httpHeaders.add("x-ncp-iam-access-key", accessKey);
+            httpHeaders.add("x-ncp-apigw-signature-v2", makeSignature(timeStamp, method.name(), url));
+            httpHeaders.setContentType(mediaType);
+            return httpHeaders;
+        } catch (Exception ex) {
+            return null;
+        }
+    }
+
+    public Object ncpHookBuildingTrigger(String timeStamp, HttpMethod method, String url) throws Exception {
+
+        HttpHeaders httpHeaders = getNcloudUserApiHeader(method, url, timeStamp);
+
+        URI uri = UriComponentsBuilder
+            .fromUriString("https://sourcebuild.apigw.ntruss.com")
+            .path(url)
+            .encode().build()
+            .toUri();
+
+        HttpEntity request = new HttpEntity(httpHeaders);
+        ResponseEntity<?> response = restTemplate.exchange(uri, HttpMethod.POST, request, String.class);
+
+        return response.getBody();
+    }
+}

--- a/src/main/java/com/skka/adaptor/controller/navercloudplatform/NcpService.java
+++ b/src/main/java/com/skka/adaptor/controller/navercloudplatform/NcpService.java
@@ -5,6 +5,7 @@ import java.nio.charset.Charset;
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
 import org.apache.tomcat.util.codec.binary.Base64;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
@@ -15,8 +16,10 @@ import org.springframework.web.util.UriComponentsBuilder;
 
 public class NcpService {
 
-    private String accessKey = "";
-    private String secretKey = "";
+    @Value("${ncp-accessKey}")
+    private String accessKey;
+    @Value("${ncp-secretKey}")
+    private String secretKey;
 
     private RestTemplate restTemplate = new RestTemplate();
 


### PR DESCRIPTION
### 이슈
[74] NCP(Naver Cloud Platform) 에서 제공하는 api로 souce build에 트리거 날리는 api 추가

### 작업사항
* 나의 클라우드 계정의 sourceBuild의 모든 프로젝트들 들고오는 API 추가
* 나의 클라우드 계정의 sourceBuild의 특정 프로젝트에 빌드 명령 트리거 발송 API 추가

### 작업 이유
* [issue 72-ci 수정](https://github.com/f-lab-edu/SSKA/pull/73)애서 언급 했듯이
* 개발자가 처음에는 NCP에서 제공하는 깃헙 같은 레포지토리 기능을 하는 SourceCommit과 GitHub 둘 다 관리를 해야하는 번거로움이 있었다. 이 문제를 해결하기 위해 깃허브 레포지토리에서 바로 들고와 build 후 배포하는 방식으로 바꾸었다.
